### PR TITLE
Disable model forms other than CLM until they are implemented.

### DIFF
--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -756,16 +756,16 @@ else:
     _import_structure["models.rwkv2"].extend(
         [
             "RWKV2_PRETRAINED_MODEL_ARCHIVE_LIST",
-            "RWKV2ForMaskedLM",
+#            "RWKV2ForMaskedLM",
             "RWKV2ForCausalLM",
-            "RWKV2ForMultipleChoice",
-            "RWKV2ForQuestionAnswering",
-            "RWKV2ForSequenceClassification",
-            "RWKV2ForTokenClassification",
-            "RWKV2Layer",
+#            "RWKV2ForMultipleChoice",
+#            "RWKV2ForQuestionAnswering",
+#            "RWKV2ForSequenceClassification",
+#            "RWKV2ForTokenClassification",
+#            "RWKV2Layer",
             "RWKV2Model",
             "RWKV2PreTrainedModel",
-            "load_tf_weights_in_rwkv2",
+#            "load_tf_weights_in_rwkv2",
         ]
     )
     _import_structure["models.albert"].extend(
@@ -3418,16 +3418,16 @@ if TYPE_CHECKING:
 
         from .models.rwkv2 import (
             RWKV2_PRETRAINED_MODEL_ARCHIVE_LIST,
-            RWKV2ForMaskedLM,
+#            RWKV2ForMaskedLM,
             RWKV2ForCausalLM,
-            RWKV2ForMultipleChoice,
-            RWKV2ForQuestionAnswering,
-            RWKV2ForSequenceClassification,
-            RWKV2ForTokenClassification,
-            RWKV2Layer,
+#            RWKV2ForMultipleChoice,
+#            RWKV2ForQuestionAnswering,
+#            RWKV2ForSequenceClassification,
+#            RWKV2ForTokenClassification,
+#            RWKV2Layer,
             RWKV2Model,
             RWKV2PreTrainedModel,
-            load_tf_weights_in_rwkv2,
+#            load_tf_weights_in_rwkv2,
         )
         from .models.albert import (
             ALBERT_PRETRAINED_MODEL_ARCHIVE_LIST,

--- a/src/transformers/models/auto/modeling_auto.py
+++ b/src/transformers/models/auto/modeling_auto.py
@@ -198,7 +198,7 @@ MODEL_FOR_PRETRAINING_MAPPING_NAMES = OrderedDict(
 MODEL_WITH_LM_HEAD_MAPPING_NAMES = OrderedDict(
     [
         # Model with LM heads mapping
-("rwkv2", "RWKV2ForMaskedLM"),
+#("rwkv2", "RWKV2ForMaskedLM"),
         ("albert", "AlbertForMaskedLM"),
         ("bart", "BartForConditionalGeneration"),
         ("bert", "BertForMaskedLM"),
@@ -385,7 +385,7 @@ MODEL_FOR_VISION_2_SEQ_MAPPING_NAMES = OrderedDict(
 MODEL_FOR_MASKED_LM_MAPPING_NAMES = OrderedDict(
     [
         # Model for Masked LM mapping
-("rwkv2", "RWKV2ForMaskedLM"),
+#("rwkv2", "RWKV2ForMaskedLM"),
         ("albert", "AlbertForMaskedLM"),
         ("bart", "BartForConditionalGeneration"),
         ("bert", "BertForMaskedLM"),
@@ -469,7 +469,7 @@ MODEL_FOR_SPEECH_SEQ_2_SEQ_MAPPING_NAMES = OrderedDict(
 MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING_NAMES = OrderedDict(
     [
         # Model for Sequence Classification mapping
-        ("rwkv2", "RWKV2ForSequenceClassification"),
+#        ("rwkv2", "RWKV2ForSequenceClassification"),
         ("albert", "AlbertForSequenceClassification"),
         ("bart", "BartForSequenceClassification"),
         ("bert", "BertForSequenceClassification"),
@@ -526,7 +526,7 @@ MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING_NAMES = OrderedDict(
 MODEL_FOR_QUESTION_ANSWERING_MAPPING_NAMES = OrderedDict(
     [
         # Model for Question Answering mapping
-        ("rwkv2", "RWKV2ForQuestionAnswering"),
+#        ("rwkv2", "RWKV2ForQuestionAnswering"),
         ("albert", "AlbertForQuestionAnswering"),
         ("bart", "BartForQuestionAnswering"),
         ("bert", "BertForQuestionAnswering"),
@@ -588,7 +588,7 @@ MODEL_FOR_VISUAL_QUESTION_ANSWERING_MAPPING_NAMES = OrderedDict(
 MODEL_FOR_TOKEN_CLASSIFICATION_MAPPING_NAMES = OrderedDict(
     [
         # Model for Token Classification mapping
-("rwkv2", "RWKV2ForTokenClassification"),
+#("rwkv2", "RWKV2ForTokenClassification"),
         ("albert", "AlbertForTokenClassification"),
         ("bert", "BertForTokenClassification"),
         ("big_bird", "BigBirdForTokenClassification"),
@@ -631,7 +631,7 @@ MODEL_FOR_TOKEN_CLASSIFICATION_MAPPING_NAMES = OrderedDict(
 MODEL_FOR_MULTIPLE_CHOICE_MAPPING_NAMES = OrderedDict(
     [
         # Model for Multiple Choice mapping
-("rwkv2", "RWKV2ForMultipleChoice"),
+#("rwkv2", "RWKV2ForMultipleChoice"),
         ("albert", "AlbertForMultipleChoice"),
         ("bert", "BertForMultipleChoice"),
         ("big_bird", "BigBirdForMultipleChoice"),

--- a/src/transformers/models/rwkv2/__init__.py
+++ b/src/transformers/models/rwkv2/__init__.py
@@ -80,16 +80,16 @@ if TYPE_CHECKING:
     else:
         from .modeling_rwkv2 import (
             RWKV2_PRETRAINED_MODEL_ARCHIVE_LIST,
-            RWKV2ForMaskedLM,
+#            RWKV2ForMaskedLM,
             RWKV2ForCausalLM,
-            RWKV2ForMultipleChoice,
-            RWKV2ForQuestionAnswering,
-            RWKV2ForSequenceClassification,
-            RWKV2ForTokenClassification,
-            RWKV2Layer,
+#            RWKV2ForMultipleChoice,
+#            RWKV2ForQuestionAnswering,
+#            RWKV2ForSequenceClassification,
+#            RWKV2ForTokenClassification,
+#            RWKV2Layer,
             RWKV2Model,
             RWKV2PreTrainedModel,
-            load_tf_weights_in_rwkv2,
+#            load_tf_weights_in_rwkv2,
         )
 
 


### PR DESCRIPTION
I noticed you had commented out these possible model parts that aren't implemented yet, so I commented them out elsewhere so they don't break tests.

This resolves the import errors failing the first tests, for now.